### PR TITLE
Accommodate correctly pluralized ViewStrings in GAP

### DIFF
--- a/doc/ref/design.tex
+++ b/doc/ref/design.tex
@@ -94,7 +94,7 @@ of <G> and their translates by group-elements as set of blocks.
     gap> f := aux[1][1];
     [ f1, f2 ] -> [ f1*f2, f1*f2^2 ]
     gap> phi := Group( f );
-    <group with 1 generators>
+    <group with 1 generator>
     gap> G := aux[2]; 
     <pc group of size 9 with 2 generators>
     gap> D3 := DesignFromFerreroPair( G, phi, "*" );

--- a/doc/ref/nfplwd.tex
+++ b/doc/ref/nfplwd.tex
@@ -173,7 +173,7 @@ representatives <reps>.
     [ f1, f1^5 ]
     gap> n := PlanarNearRing( C7, phi, reps );
     ExplicitMultiplicationNearRing ( <pc group of size 7 with 
-    1 generators> , multiplication )
+    1 generator> , multiplication )
 \endexample
 
 \>OrbitRepresentativesForPlanarNearRing( <G>, <phi>, <i> )

--- a/doc/ref/nr.tex
+++ b/doc/ref/nr.tex
@@ -174,7 +174,7 @@ nearring <nr>. This function works the same way as for groups.
 \beginexample
     gap> n := ExplicitMultiplicationNearRingNC( CyclicGroup( 3 ), mul_l );
     ExplicitMultiplicationNearRing ( <pc group of size 3 with 
-    1 generators> , multiplication )
+    1 generator> , multiplication )
     gap> SetSymbols( n, ["0","1","2"] );
     gap> PrintTable( n );               
     Let:

--- a/doc/ref/tfms.tex
+++ b/doc/ref/tfms.tex
@@ -122,11 +122,11 @@ which maps everything to the group element <g> of <G>.
 
 \beginexample
     gap> C3 := CyclicGroup (3);
-    <pc group of size 3 with 1 generators>
+    <pc group of size 3 with 1 generator>
     gap> m := ConstantEndoMapping (C3, AsSortedList (C3) [2]);
     MappingByFunction( <pc group of size 3 with 
-    1 generators>, <pc group of size 3 with 
-    1 generators>, function( x ) ... end )
+    1 generator>, <pc group of size 3 with 
+    1 generator>, function( x ) ... end )
     gap> List (AsList (C3), x -> Image (m, x));
     [ f1, f1, f1 ]
 \endexample
@@ -154,7 +154,7 @@ function on a group.
 
 \beginexample
     gap> C3 := CyclicGroup ( 3 );
-    <pc group of size 3 with 1 generators>
+    <pc group of size 3 with 1 generator>
     gap> IsConstantEndoMapping ( EndoMappingByFunction ( C3,  x -> x^3 ));
     true
 \endexample

--- a/tst/fpf.tst
+++ b/tst/fpf.tst
@@ -163,9 +163,7 @@ gap> orbs := Orbits( phi, C7 );
 [ [ <identity> of ... ], [ f1, f1^6 ], [ f1^2, f1^5 ], [ f1^3, f1^4 ] ]
 gap> reps := [orbs[2][1], orbs[3][2]];
 [ f1, f1^5 ]
-gap> n := PlanarNearRing( C7, phi, reps );
-ExplicitMultiplicationNearRing ( <pc group of size 7 with 
-1 generators> , multiplication )
+gap> n := PlanarNearRing( C7, phi, reps );;
 gap> C7 := CyclicGroup( 7 );;
 gap> i := GroupHomomorphismByFunction( C7, C7, x -> x^-1 );;
 gap> phi := Group( i );;
@@ -198,8 +196,9 @@ gap> aux := FpfAutomorphismGroupsCyclic( [3,3], 4 );
   <pc group of size 9 with 2 generators> ]
 gap> f := aux[1][1];
 [ f1, f2 ] -> [ f1*f2, f1*f2^2 ]
-gap> phi := Group( f );
-<group with 1 generators>
+gap> phi := Group( f );;
+gap> IsCyclic(phi);
+true
 gap> G := aux[2]; 
 <pc group of size 9 with 2 generators>
 gap> D3 := DesignFromFerreroPair( G, phi, "*" );

--- a/tst/nr.tst
+++ b/tst/nr.tst
@@ -54,9 +54,7 @@ DirectProductNearRing( ExplicitMultiplicationNearRing ( 18/3 , multiplication \
 ), ExplicitMultiplicationNearRing ( 12/3 , multiplication ) )
 gap> IsExplicitMultiplicationNearRing( d );
 true
-gap> n := ExplicitMultiplicationNearRingNC( CyclicGroup( 3 ), mul_l );
-ExplicitMultiplicationNearRing ( <pc group of size 3 with 
-1 generators> , multiplication )
+gap> n := ExplicitMultiplicationNearRingNC( CyclicGroup( 3 ), mul_l );;
 gap> SetSymbols( n, ["0","1","2"] );
 gap> PrintTable( n );               
 Let:

--- a/tst/tfms.tst
+++ b/tst/tfms.tst
@@ -32,18 +32,14 @@ gap> AsList ( UnderlyingRelation ( IdentityEndoMapping ( Group ((1,2,3,4)) ) ) )
   DirectProductElement( [ (1,2,3,4), (1,2,3,4) ] ), 
   DirectProductElement( [ (1,3)(2,4), (1,3)(2,4) ] ), 
   DirectProductElement( [ (1,4,3,2), (1,4,3,2) ] ) ]
-gap> C3 := CyclicGroup (3);
-<pc group of size 3 with 1 generators>
-gap> m := ConstantEndoMapping (C3, AsSortedList (C3) [2]);
-MappingByFunction( <pc group of size 3 with 1 generators>, <pc group of size 
-3 with 1 generators>, function( x ) ... end )
+gap> C3 := CyclicGroup (3);;
+gap> m := ConstantEndoMapping (C3, AsSortedList (C3) [2]);;
 gap> List (AsList (C3), x -> Image (m, x));
 [ f1, f1, f1 ]
 gap> IsIdentityEndoMapping (EndoMappingByFunction ( 
 > AlternatingGroup ( [1..5] ), x -> x^31));
 true
-gap> C3 := CyclicGroup ( 3 );
-<pc group of size 3 with 1 generators>
+gap> C3 := CyclicGroup ( 3 );;
 gap> IsConstantEndoMapping ( EndoMappingByFunction ( C3,  x -> x^3 ));
 true
 gap> G := Group ( (1,2,3), (1,2) );


### PR DESCRIPTION
In a future version of GAP, some nouns will be correctly pluralised to match their number.  For example, the `ViewString` for `CyclicGroup(3);` will change from `<pc group of size 3 with 1 generators>` to `<pc group of size 3 with 1 generator>`. (See gap-system/gap#3992 and gap-system/gap#4050 for more context.)

In this PR, I am trying maintain the backwards and forwards compatibility of this package with GAP. I have done this by suppressing the incorrectly spelled output in tests, and adopting the new output in the `.tex` files (which I assume are not run through any automated tests?)

Please let me know if this is sufficient - perhaps it was actually important to keep some of the output that I have now suppressed?