### PR TITLE
rm extra hyphen, mention Gap.app as xgap alternate

### DIFF
--- a/doc/ref/xsonata.tex
+++ b/doc/ref/xsonata.tex
@@ -1,8 +1,8 @@
 %
-\Chapter{Graphic ideal lattices (X-GAP only)}
+\Chapter{Graphic ideal lattices (XGAP only)}
 %
 
-If you run SONATA under XGAP it is possible to study ideal lattices of
+If you run SONATA under XGAP or Gap.app, it is possible to study ideal lattices of
 nearrings graphically.
 
 \>GraphicIdealLattice( <nr>, <string> )


### PR DESCRIPTION
XGAP is usually rendered without a hyphen, and probably should be in the title also.

I am biased, but I suspect that more users use the xgap library via Gap.app than via xgap.  It seems worthwhile to mention it briefly here, and while I am submitting a PR I have added it.